### PR TITLE
fix(ci): remove redundant step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ jobs:
       - name: install dependencies
         run: npm ci
 
-      - name: run debug script
-        run: ./debug-check.sh
-
       - name: check formatting on diff
         id: prettier
         shell: bash


### PR DESCRIPTION
## Why

The CI pipeline fails because it still references a shell script that has already been removed

## What

remove the redundant step from `ci.yml`