### PR TITLE
feat: 調整 danger 顏色 / 修改 border 顏色變數

### DIFF
--- a/assets/scss/utils/_bs-variables.scss
+++ b/assets/scss/utils/_bs-variables.scss
@@ -35,9 +35,6 @@ $spacer: 1rem !default;
 // * Custom Variables
 // *******************************
 
-// color-variables
-$red-500: #ff583d !default;
-
 // primary-color-variables
 $primary-900: #39401d !default;
 $primary-800: #515a30 !default;
@@ -90,6 +87,16 @@ $neutrals: (
   '50': $neutral-50,
 ) !default;
 
+// danger-color-variables
+$danger-500: #ff583d !default;
+$danger-200: #ffc9c0 !default;
+$danger-100: #ffe9e5 !default;
+$dangers: (
+  '500': $danger-500,
+  '200': $danger-200,
+  '100': $danger-100,
+) !default;
+
 // font-variables
 $h7-font-size: $font-size-base * 1.125 !default;
 $h8-font-size: $font-size-base !default;
@@ -101,7 +108,7 @@ $h8-font-size: $font-size-base !default;
 // theme-color-variables
 $primary: $primary-600 !default;
 $secondary: $secondary-600 !default;
-$danger: $red-500 !default;
+$danger: $danger-500 !default;
 
 // theme-colors-map
 $theme-colors: (
@@ -136,6 +143,9 @@ $theme-colors: (
   'neutral-200': $neutral-200,
   'neutral-100': $neutral-100,
   'neutral-50': $neutral-50,
+  // danger
+  'danger-200': $danger-200,
+  'danger-100': $danger-100,
 ) !default;
 
 // spacer-variables-maps
@@ -230,3 +240,6 @@ $line-height-sm: 1.2 !default;
 
 // btn
 $btn-font-weight: $font-weight-medium !default;
+
+// border-color
+$border-color: $neutral-200 !default;


### PR DESCRIPTION
## 摘要

<!-- 請簡要說明此 PR 的內容與目的 -->
設計稿顏色變動
- 原本 red-500 改成 danger-500，並新增 danger-200, danger-100

border 底線變數
- 調整 bootstrap 設定，底線顏色預設改為 $neutral-200

## 檢查清單

<!-- 請填寫以下清單，刪除不適用的項目。 -->

- [ ] RWD 是否正確套用(PC/Mobile)
  - 伸縮時不可以出現 x 軸與跑版的狀況
- [ ] 畫面無明顯錯誤或問題
  - 按鈕/連結效果(hover是否有正確樣式、是否可連結到正確畫面等等)

<!-- 其他補充說明。若有，請將下列備註欄取消註解，加註在備註欄中 -->

<!-- ## 備註 -->
