### PR TITLE
feat: Bootstrap 調整 input-placeholder-color 為 neutral-300

### DIFF
--- a/assets/scss/utils/_bs-variables.scss
+++ b/assets/scss/utils/_bs-variables.scss
@@ -244,3 +244,6 @@ $btn-font-weight: $font-weight-medium !default;
 
 // border-color
 $border-color: $neutral-200 !default;
+
+// input
+$input-placeholder-color: $neutral-300 !default;


### PR DESCRIPTION
## 摘要

<!-- 請簡要說明此 PR 的內容與目的 -->
調整 Bootstrap 變數設定：input-placeholder-color 設定為 neutral-300

<!-- ## 檢查清單 -->

<!-- 請填寫以下清單，刪除不適用的項目。 -->

<!-- - [ ] RWD 是否正確套用(PC/Mobile)
  - 伸縮時不可以出現 x 軸與跑版的狀況
- [ ] 畫面無明顯錯誤或問題
  - 按鈕/連結效果(hover是否有正確樣式、是否可連結到正確畫面等等) -->

<!-- 其他補充說明。若有，請將下列備註欄取消註解，加註在備註欄中 -->

<!-- ## 備註 -->
