### PR TITLE
fix: correct reload path of ejs components

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig({
   // base: '/Repository 的名稱/'
   base: '/plantique-life/',
   plugins: [
-    liveReload(['./layout/**/*.ejs', './pages/**/*.ejs', './pages/**/*.html']),
+    liveReload(['./layout/**/*.ejs', './components/**/*.ejs', './pages/**/*.html']),
     ViteEjsPlugin(),
     moveOutputPlugin(),
   ],


### PR DESCRIPTION
## 摘要

修正 `liveReload()` 監聽路徑下，元件ejs檔路徑是舊的，開發模式時不會自動更新的問題。
