### PR TITLE
fix: 避免手機版 fixed 按鈕點擊事件冒泡，觸發下方元素

### DIFF
--- a/assets/js/shopping-cart.js
+++ b/assets/js/shopping-cart.js
@@ -679,7 +679,8 @@ purchaserEmailEl.addEventListener('input', () => {
 });
 
 // 付款資料 → demo 按鈕事件：自動填入資料
-demoBtnEl.addEventListener('click', () => {
+demoBtnEl.addEventListener('click', e => {
+  e.stopPropagation();
   // 運送方式
   const deliveryToggleEl = document.getElementById('delivery-toggle');
   deliveryToggleEl.textContent = orderInfo.delivery.method;


### PR DESCRIPTION
## 摘要

<!-- 請簡要說明此 PR 的內容與目的 -->
在手機版時，demo 按鈕會和頁面標題 logo 重疊，導致點擊事件冒泡到下方元素。
已修改 demo 按鈕，阻止事件冒泡，避免觸發下方元素行為。

<!-- ## 檢查清單 -->

<!-- 請填寫以下清單，刪除不適用的項目。 -->

<!-- - [ ] RWD 是否正確套用(PC/Mobile)
  - 伸縮時不可以出現 x 軸與跑版的狀況
- [ ] 畫面無明顯錯誤或問題
  - 按鈕/連結效果(hover是否有正確樣式、是否可連結到正確畫面等等) -->

<!-- 其他補充說明。若有，請將下列備註欄取消註解，加註在備註欄中 -->

<!-- ## 備註 -->
