### PR TITLE
fix: remove duplicate stretched-link

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -92,9 +92,7 @@
                   <div class="row">
                     <div class="col-lg-3 d-none d-lg-flex justify-content-center">
                       <a href="#" class="stretched-link">
-                        <a href="#" class="stretched-link">
-                          <h3 class="vertical-lr fs-3 fs-lg-2 text-primary mx-0">療 癒 組 盆</h3>
-                        </a>
+                        <h3 class="vertical-lr fs-3 fs-lg-2 text-primary mx-0">療 癒 組 盆</h3>
                       </a>
                     </div>
                     <div class="col-lg-9 mt-lg-auto">


### PR DESCRIPTION
## 摘要

修正首頁-主題挑選區塊中，重複的 `stretched-link`。

## 檢查清單

<!-- 請填寫以下清單，刪除不適用的項目。 -->

- [x] 畫面無明顯錯誤或問題
  - 按鈕/連結效果(hover是否有正確樣式、是否可連結到正確畫面等等)
