### PR TITLE
style:修改breadcrumb的style

### DIFF
--- a/components/breadcrumb.ejs
+++ b/components/breadcrumb.ejs
@@ -1,5 +1,5 @@
 <nav style="--bs-breadcrumb-divider: 'chevron_right'" aria-label="breadcrumb">
-  <ol class="breadcrumb fs-sm fs-lg-8 mb-6 mb-lg-12">
+  <ol class="breadcrumb fs-sm fs-lg-8 mb-0">
     <% items.forEach((item, i) => { %>
     <li class="breadcrumb-item d-flex align-items-center <%= i === items.length - 1 ? 'active' : '' %>">
       <% if (i === items.length - 1) { %> <%= item.name %> <% } else { %>

--- a/pages/product-detail.html
+++ b/pages/product-detail.html
@@ -12,30 +12,32 @@
 
     <section class="py-8 py-lg-13">
       <div class="container">
-        <!-- prettier-ignore -->
-        <%- include('./components/breadcrumb',
-            {
-              items: [
-                {
-                  name: '首頁',
-                  link: 'index.html',
-                },
-                {
-                  name: '植感精選',
-                  link: '#',
-                },
-                {
-                  name: '療癒組盆',
-                  link: '#',
-                },
-                {
-                  name: '荒原綠影',
-                  link: '#',
-                },
-              ]
-            }
-          );
-        -%>
+        <div class="mb-6 mb-lg-12">
+          <!-- prettier-ignore -->
+          <%- include('./components/breadcrumb',
+              {
+                items: [
+                  {
+                    name: '首頁',
+                    link: 'index.html',
+                  },
+                  {
+                    name: '植感精選',
+                    link: '#',
+                  },
+                  {
+                    name: '療癒組盆',
+                    link: '#',
+                  },
+                  {
+                    name: '荒原綠影',
+                    link: '#',
+                  },
+                ]
+              }
+            );
+          -%>
+        </div>
       </div>
 
       <div class="container">


### PR DESCRIPTION
## 摘要

因為原本的麵包屑元件的style不適用於產品列表頁，因此做了以下變更:
清除breadcrumb.ejs的margin-bottom設定
將margin-bottom移到外層

## 檢查清單

<!-- 請填寫以下清單，刪除不適用的項目。 -->

- [x] RWD 是否正確套用(PC/Mobile)
  - 伸縮時不可以出現 x 軸與跑版的狀況
- [x] 畫面無明顯錯誤或問題
  - 按鈕/連結效果(hover是否有正確樣式、是否可連結到正確畫面等等)
