### PR TITLE
fix: 修正 header 桌面版會員選單抖動問題

### DIFF
--- a/layout/header.ejs
+++ b/layout/header.ejs
@@ -50,16 +50,20 @@
             <span class="material-symbols-rounded d-block"> person </span>
           </button>
           <!-- 會員選單內容 -->
-          <ul class="collapse position-absolute list-unstyled bg-white text-center p-6 member-menu" id="memberMenu">
-            <li class="mb-3"><a class="member-menu-link" href="#">會員中心</a></li>
-            <li class="pb-6">
-              <a class="member-menu-link" href="#">訂單查詢</a>
-            </li>
-            <li class="pt-6 separator-line-top">
-              <a class="member-menu-link py-1 d-flex justify-content-center align-items-center" href="#"
-                >登出 <span class="ms-2 material-symbols-rounded"> logout </span></a
-              >
-            </li>
+          <ul class="collapse position-absolute list-unstyled bg-white text-center member-menu" id="memberMenu">
+            <ul class="list-unstyled p-6">
+              <li class="mb-3"><a class="member-menu-link" href="#">會員中心</a></li>
+              <li>
+                <a class="member-menu-link" href="#">訂單查詢</a>
+              </li>
+            </ul>
+            <ul class="list-unstyled px-6 pb-6">
+              <li class="pt-6 separator-line-top">
+                <a class="member-menu-link py-1 d-flex justify-content-center align-items-center" href="#"
+                  >登出 <span class="ms-2 material-symbols-rounded"> logout </span></a
+                >
+              </li>
+            </ul>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
## 摘要

修正 header 桌面版會員選單抖動問題

## 檢查清單

<!-- 請填寫以下清單，刪除不適用的項目。 -->

- [x] RWD 是否正確套用(PC/Mobile)
  - 伸縮時不可以出現 x 軸與跑版的狀況
- [x] 畫面無明顯錯誤或問題
  - 按鈕/連結效果(hover是否有正確樣式、是否可連結到正確畫面等等)

<!-- 其他補充說明。若有，請將下列備註欄取消註解，加註在備註欄中 -->

<!-- ## 備註 -->
