### PR TITLE
fix: 產品詳細頁更新 icon font 並補引入 btn-fav

### DIFF
--- a/assets/scss/product-detail.scss
+++ b/assets/scss/product-detail.scss
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded');
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,0');
 
 @import './utils/custom-bs';
 
@@ -16,6 +16,7 @@
 @import './components/buttons/btn-filled-or-outline';
 @import './components/breadcrumb';
 @import './components/product-card';
+@import './components/buttons/btn-fav';
 
 // section
 


### PR DESCRIPTION
## 摘要

產品詳細頁更新 icon font 並補引入 btn-fav，使產品卡片樣式符合預期

## 檢查清單

<!-- 請填寫以下清單，刪除不適用的項目。 -->

- [x] RWD 是否正確套用(PC/Mobile)
  - 伸縮時不可以出現 x 軸與跑版的狀況
- [x] 畫面無明顯錯誤或問題
  - 按鈕/連結效果(hover是否有正確樣式、是否可連結到正確畫面等等)

<!-- 其他補充說明。若有，請將下列備註欄取消註解，加註在備註欄中 -->

<!-- ## 備註 -->
