### PR TITLE
fix: 修正提醒 modal 顯示資訊未同步問題

### DIFF
--- a/assets/js/shopping-cart.js
+++ b/assets/js/shopping-cart.js
@@ -88,18 +88,18 @@ const orderInfo = {
   },
   payment: {
     method: '信用卡一次付清',
-    creditCardInfo: { number: ['1111', '2222', '3333', '4444'], exp: ['31', '01'], cvc: '123' },
+    creditCardInfo: { number: ['1111', '2222', '3333', '4444'], exp: ['01', '28'], cvc: '123' },
   },
   purchaser: {
     name: '王小明',
-    tel: '0912345678',
+    tel: '0912-345-678',
     email: 'plantique@test.com',
   },
   recipient: {
     name: '王小明',
-    tel: '0912345678',
+    tel: '0912-345-678',
     email: 'plantique@test.com',
-    address: '台北市信義區',
+    address: '台北市信義區松仁路100號',
   },
   invoice: {
     method: '雲端載具',
@@ -819,6 +819,11 @@ function confirmCheckoutData() {
     return;
   }
 
+  // 顯示確認 Modal 資料
+  confirmModalNameEl.textContent = recipientNameEl.value;
+  confirmModalPhoneEl.textContent = recipientPhoneEl.value;
+  confirmModalAddressEl.textContent = recipientAddressEl.value;
+
   confirmModal.show();
 }
 // 前往訂單完成
@@ -1169,27 +1174,18 @@ purchaserEmailEl.addEventListener('input', e => {
     // 若同訂購人資料的 checkbox 有勾選，則收件人電子郵件同步訂購人電子郵件
     if (recipientCheckedEl.checked) {
       recipientEmailEl.value = e.target.value;
-      confirmModalAddressEl.textContent = e.target.value;
+      recipientEmailEl.textContent = e.target.value;
     }
   }
 });
 // 付款資料 → 收件人姓名
-recipientNameEl.addEventListener(
-  'input',
-  e => checkSchema(e.target, 'recipientName') && (confirmModalNameEl.textContent = e.target.value),
-);
+recipientNameEl.addEventListener('input', e => checkSchema(e.target, 'recipientName'));
 // 付款資料 → 收件人電話號碼
-recipientPhoneMask.on(
-  'accept',
-  e => checkSchema(e.target, 'recipientPhone') && (confirmModalPhoneEl.textContent = e.target.value),
-);
+recipientPhoneMask.on('accept', e => checkSchema(e.target, 'recipientPhone'));
 // 付款資料 → 收件人電子郵件
 recipientEmailEl.addEventListener('input', e => checkSchema(e.target, 'recipientEmail'));
 // 付款資料 → 收件人地址
-recipientAddressEl.addEventListener(
-  'input',
-  e => checkSchema(e.target, 'recipientAddress') && (confirmModalAddressEl.textContent = e.target.value),
-);
+recipientAddressEl.addEventListener('input', e => checkSchema(e.target, 'recipientAddress'));
 // 付款資料 → 手機條碼
 mobileBarcodeEl.addEventListener('input', e => checkSchema(e.target, 'mobileBarcode'));
 // 付款資料 → 統一編號


### PR DESCRIPTION
## 摘要

<!-- 請簡要說明此 PR 的內容與目的 -->
- 提醒視窗 modal 的資料調整成在視窗 show 之前才將資料更新和「付款資料畫面」相同
- 修正訂購人電子郵件 input 事件：若同訂購人資料的 checkbox 勾選，應是同步更新收件人電子郵件

<!-- ## 檢查清單 -->

<!-- 請填寫以下清單，刪除不適用的項目。 -->

<!-- - [ ] RWD 是否正確套用(PC/Mobile)
  - 伸縮時不可以出現 x 軸與跑版的狀況
- [ ] 畫面無明顯錯誤或問題
  - 按鈕/連結效果(hover是否有正確樣式、是否可連結到正確畫面等等) -->

<!-- 其他補充說明。若有，請將下列備註欄取消註解，加註在備註欄中 -->

<!-- ## 備註 -->
