### PR TITLE
fix: 修正背景圖在實際部署時找不到路徑的問題

### DIFF
--- a/assets/scss/pages/_column-detail.scss
+++ b/assets/scss/pages/_column-detail.scss
@@ -4,7 +4,7 @@
   left: 0;
   width: 100%;
   height: 600px;
-  background: url('../assets/images/img_column_07.png') no-repeat right 50% / cover;
+  background: url('../images/img_column_07.png') no-repeat right 50% / cover;
   z-index: -1;
   &::before {
     content: '';


### PR DESCRIPTION
## 摘要

<!-- 請簡要說明此 PR 的內容與目的 -->
- 本地開發（`npm run dev`）時背景圖顯示正常，但部署後因路徑設定錯誤導致圖片無法載入。
- 已調整背景圖路徑，確保在本機開發與部署環境下皆能正常顯示。

<!-- ## 檢查清單 -->

<!-- 請填寫以下清單，刪除不適用的項目。 -->

<!-- - [ ] RWD 是否正確套用(PC/Mobile)
  - 伸縮時不可以出現 x 軸與跑版的狀況
- [ ] 畫面無明顯錯誤或問題
  - 按鈕/連結效果(hover是否有正確樣式、是否可連結到正確畫面等等) -->

<!-- 其他補充說明。若有，請將下列備註欄取消註解，加註在備註欄中 -->

<!-- ## 備註 -->

