### PR TITLE
feat: 新增文章列表與詳細頁的導覽連結

### DIFF
--- a/pages/article-list.html
+++ b/pages/article-list.html
@@ -146,7 +146,7 @@
                     </p>
                     <div class="d-flex justify-content-between align-items-center">
                       <p class="fs-xs fs-lg-sm text-primary-500">2025/01/01</p>
-                      <a href="#" class="d-flex justify-content-end">
+                      <a href="./column-detail.html" class="d-flex justify-content-end">
                         <%-include('./components/buttons/btn-link', btnLinkPrimary); -%>
                       </a>
                     </div>

--- a/pages/column-detail.html
+++ b/pages/column-detail.html
@@ -25,7 +25,7 @@
           <!-- prettier-ignore -->
           <%- include('./components/breadcrumb', {
             items: [
-              { name: '植藝生活', link: '#' },
+              { name: '植藝生活', link: './article-list.html' },
               { name: '養護專欄', link: '#' },
               { name: '在陽台種一盆療癒：多肉植物打造你的綠意角落', link: '#' },
             ],


### PR DESCRIPTION
## 摘要

<!-- 請簡要說明此 PR 的內容與目的 -->
- 新增文章列表與詳細頁的導覽連結。
  - 文章列表頁第一個區塊（#養護指南）的第三篇文章，點擊「閱讀全文」可導向至文章詳細頁。
  - 文章詳細頁的麵包屑中，點擊「植藝生活」可返回文章列表頁。

<!-- ## 檢查清單 -->

<!-- 請填寫以下清單，刪除不適用的項目。 -->

<!-- - [ ] RWD 是否正確套用(PC/Mobile)
  - 伸縮時不可以出現 x 軸與跑版的狀況
- [ ] 畫面無明顯錯誤或問題
  - 按鈕/連結效果(hover是否有正確樣式、是否可連結到正確畫面等等) -->

<!-- 其他補充說明。若有，請將下列備註欄取消註解，加註在備註欄中 -->

## 備註
- 本 PR 基於分支 [feature/add-anchor-function](https://github.com/kira134679/plantique-life/tree/feature/add-anchor-function) 進行後續修改，該分支的 PR #76 目前尚未合併到 main。
- 當前異動檔案包含上述分支的內容，請先確認 #76 。
