### PR TITLE
feat: add jsconfig.json to enable proper intellisense in vscode

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "allowImportingTsExtensions": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strict": true,
+    "paths": {
+      "@/*": ["./src/*"],
+      "assets": ["./src/assets"]
+    }
+  },
+  "exclude": ["node_modules", "**/node_modules/*"]
+}


### PR DESCRIPTION
## 摘要

加入 `jsconfig.json` ，讓 vscode 的 IntelliSense (提示功能) 在使用了 vite 的 alias 功能時也能正常運作。

包含:

- 懸停提示
- 自動匯入

等等。

## 備註

加入前:

<img width="448" height="130" alt="Code_nYEtAx9tyP" src="https://github.com/user-attachments/assets/eb28db0b-5e3b-4e28-a54c-0b00ed31c19e" />

加入後:

<img width="1029" height="202" alt="Code_r1vwAp3vx5" src="https://github.com/user-attachments/assets/106aa216-9c76-40b6-b35f-39a136ca290b" />

