### PR TITLE
fix: follow up on admin login/logout flow fixes

### DIFF
--- a/src/assets/scss/layout/_header.scss
+++ b/src/assets/scss/layout/_header.scss
@@ -46,6 +46,11 @@
   }
 }
 
+.disabled-link {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
 .cart-toggle-btn {
   color: $neutral-700;
   padding: map.get($spacers, 2);
@@ -124,10 +129,10 @@
   .offcanvas-body {
     pointer-events: auto;
   }
-  .custom-nav-link:hover {
+  .custom-nav-link:hover:not(.disabled-link) {
     background-color: $primary-50;
   }
-  .custom-nav-link:active {
+  .custom-nav-link:active:not(.disabled-link) {
     background-color: $primary-100;
   }
 }

--- a/src/components/RequireAuth.jsx
+++ b/src/components/RequireAuth.jsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Navigate, Outlet } from 'react-router';
 
 export default function RequireAuth() {
-  const { isAuth, authChecked } = useSelector(state => state.auth);
+  const { isAuth, authChecked, isLoggingOut } = useSelector(state => state.auth);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -12,6 +12,8 @@ export default function RequireAuth() {
       dispatch(checkAuth());
     }
   }, [dispatch, authChecked]);
+
+  if (isLoggingOut) return null;
 
   if (!authChecked) return null; // 避免非同步的時間差，導致非預期的渲染結果
 

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -1,15 +1,16 @@
+import { logout } from '@/slice/authSlice';
 import { deleteAndRefetchCarts, fetchCarts, selectHasItemLoading, updateAndRefetchCarts } from '@/slice/cartSlice';
 import useMediaQuery from '@/utils/useMediaQuery';
 import logoSm from 'assets/images/logo-primary-en-sm.svg';
 import logoLg from 'assets/images/logo-primary-en-zh-lg.svg';
 import clsx from 'clsx';
+import Cookie from 'js-cookie';
 import { useEffect, useRef, useState } from 'react';
 import { Collapse, Offcanvas } from 'react-bootstrap';
 import toast from 'react-hot-toast';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link, useLocation, useNavigate } from 'react-router';
 import Button from '../components/Button';
-import { logout } from '@/slice/authSlice';
 
 export default function Navbar() {
   const dispatch = useDispatch();
@@ -28,13 +29,11 @@ export default function Navbar() {
   const handleLogout = async () => {
     try {
       await dispatch(logout()).unwrap();
-      //清除cookie
-      document.cookie = 'auth_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+      Cookie.remove('auth_token');
       toast.success('已登出');
+      navigate('/', { replace: true });
     } catch {
       toast.error('登出失敗');
-    } finally {
-      navigate('/', { replace: true });
     }
   };
 

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -190,7 +190,7 @@ export default function Navbar() {
                       variant="filled-primary"
                       shape="pill"
                       size="sm"
-                      className="text-nowrap cursor-not-allowed"
+                      className="text-nowrap"
                       disabled
                     >
                       註冊
@@ -277,7 +277,7 @@ export default function Navbar() {
                   </li>
                   <li className="pb-6">
                     <Link
-                      className="custom-nav-link cursor-not-allowed"
+                      className="custom-nav-link disabled-link"
                       to="#"
                       aria-disabled="true"
                       onClick={e => e.preventDefault()}

--- a/src/layout/admin/Header.jsx
+++ b/src/layout/admin/Header.jsx
@@ -1,9 +1,10 @@
-import logoImg from 'assets/images/logo-primary-en-zh-lg.svg';
-import { Link, useNavigate } from 'react-router';
-import { useDispatch } from 'react-redux';
-import { logout } from '@/slice/authSlice';
-import toast from 'react-hot-toast';
 import Button from '@/components/Button';
+import { logout } from '@/slice/authSlice';
+import logoImg from 'assets/images/logo-primary-en-zh-lg.svg';
+import Cookie from 'js-cookie';
+import toast from 'react-hot-toast';
+import { useDispatch } from 'react-redux';
+import { Link, useNavigate } from 'react-router';
 
 function Header() {
   const dispatch = useDispatch();
@@ -12,13 +13,11 @@ function Header() {
   const handleLogout = async () => {
     try {
       await dispatch(logout()).unwrap();
-      //清除cookie
-      document.cookie = 'auth_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+      Cookie.remove('auth_token');
       toast.success('已登出');
+      navigate('/', { replace: true });
     } catch {
       toast.error('登出失敗');
-    } finally {
-      navigate('/', { replace: true });
     }
   };
 

--- a/src/router/routes.jsx
+++ b/src/router/routes.jsx
@@ -38,7 +38,10 @@ const routes = [
     HydrateFallback: () => null,
     loader: async () => {
       store.dispatch(getAllProducts());
-      store.dispatch(checkAuth());
+      const { authChecked } = store.getState().auth;
+      if (!authChecked) {
+        store.dispatch(checkAuth());
+      }
       return null;
     },
     children: [

--- a/src/slice/authSlice.js
+++ b/src/slice/authSlice.js
@@ -30,6 +30,7 @@ export const authSlice = createSlice({
   initialState: {
     isAuth: false,
     authChecked: false,
+    isLoggingOut: false,
   },
   reducers: {
     setIsAuth(state, { payload }) {
@@ -40,9 +41,18 @@ export const authSlice = createSlice({
     },
   },
   extraReducers: builder => {
+    builder.addCase(logout.pending, state => {
+      state.isLoggingOut = true;
+    });
+
     builder.addCase(logout.fulfilled, state => {
       state.isAuth = false;
-      state.authChecked = false;
+      state.authChecked = true;
+      state.isLoggingOut = false;
+    });
+
+    builder.addCase(logout.rejected, state => {
+      state.isLoggingOut = false;
     });
 
     builder.addMatcher(isAnyOf(login.fulfilled, checkAuth.fulfilled), (state, { payload }) => {
@@ -58,4 +68,4 @@ export const authSlice = createSlice({
 });
 
 export default authSlice.reducer;
-export const { setIsAuth, setAuthChecked, resetAuth } = authSlice.actions;
+export const { setIsAuth, setAuthChecked } = authSlice.actions;

--- a/src/views/Login.jsx
+++ b/src/views/Login.jsx
@@ -45,8 +45,10 @@ export default function Login() {
   };
 
   useEffect(() => {
-    dispatch(checkAuth());
-  }, [dispatch]);
+    if (!authChecked) {
+      dispatch(checkAuth());
+    }
+  }, [dispatch, authChecked]);
 
   if (!authChecked) return null; // 避免非同步的時間差，導致非預期的渲染結果
 


### PR DESCRIPTION
## 摘要

補全 `Fix/admin-login-and-logout` 需要調整的部分:

- 修正手機版會員註冊連結的禁用樣式
- 修正 `handleLogout` 行為，確保成功時才導向首頁，而不是用 finally
- 調整: 使用 `js-cookie` 提供的 `remove` 方法，在登出成功時移除 cookie
- 使用 `isLoggingOut` 優化登出時的行為判斷，避免登出時先跳到 Login 才跳到首頁
- `route root`, `Login` 補上條件判斷，避免無條件重複驗證 

## 備註

此份PR包含的調整並非完美解決方案，但可暫時性解決目前需要修正的問題。
